### PR TITLE
Feature/adding splicing pipeline tests to ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,7 @@ jobs:
           name: Run tests
           working_directory: /splicing-pipeline/pipeline/splicing
           command: |
-            make references -e IMAGE_NAME=splicing-pipeline -e REFERENCES=/splicing-pipeline/references
-            make short -e IMAGE_NAME=splicing-pipeline -e REFERENCES=/splicing-pipeline/references
+            make unit_tests_docker -e IMAGE_NAME=splicing-pipeline
 workflows:
    version: 2
    build-n-deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,6 +1,6 @@
 version: 2
 jobs:
-   build:
+   buildweb:
      docker:
        - image: circleci/node:6.13
        - image: circleci/postgres:9.6.2
@@ -35,22 +35,8 @@ jobs:
              pip install -r ~/project/website/test-requirements.txt
              cd ~/project/website/django && python manage.py migrate
              python manage.py test
-       - run:
-           name: Set up up run pipeline tests
-           command: |
-             mkdir ~/project/pipeline_virtualenv
-             virtualenv ~/project/pipeline_virtualenv
-             source ~/project/pipeline_virtualenv/bin/activate
-             pip install pip==9.0.3 # downgrading pip otherwise issues with the hgvs package install below
-             git clone https://github.com/counsyl/hgvs.git
-             cd hgvs && git checkout aebe5bd9683f4b5937fd653ce4b13fcd4f3ebb10 && python setup.py install
-             pip install -r ~/project/pipeline/requirements.txt
-             pip install -r ~/project/test-requirements.txt
-             cd ~/project/pipeline/data && bash ./getdata
-             cd ~/project/pipeline && pytest --ignore=website/ --junitxml=~/test_reports/pytest-results.xml
        - store_test_results:
            path: ~/test_reports
-    
    deploy-dev:
      docker:
        - image: circleci/node:6.13
@@ -93,23 +79,76 @@ jobs:
        - run:
            name: deploying to beta machine
            command: HOST=brcaexchange.org ~/project/deployment/deploy-dev
+   test-pipeline:
+     working_directory: /pipeline
+     docker:
+       - image: docker:17.05.0-ce-git
+       # heavily inspired from https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
+     steps:
+       - checkout
+       - setup_remote_docker
+       - run:
+           name: Install dependencies
+           command: |
+             apk add --no-cache \
+               py-pip=9.0.0-r1
+             pip install \
+              docker-compose==1.12.0
+       - restore_cache:
+           keys:
+             - v1-{{ .Branch }}
+           paths:
+             - /caches/pipeline.tar
+       - run:
+           name: Load Docker image layer cache
+           command: |
+             set +o pipefail
+             docker load -i /caches/pipeline.tar | true
+       - run:
+           name: Build application Docker image
+           working_directory: /pipeline/pipeline/docker
+           command: |
+             pwd
+             echo $(pwd)
+             cp ../requirements.txt requirements_docker.txt
+             cp ../../test-requirements.txt test-requirements_docker.txt
+             docker build --cache-from=pipeline -t pipeline .
+       - run:
+           name: Save Docker image layer cache
+           command: |
+             mkdir -p /caches
+             docker save -o /caches/pipeline.tar pipeline
+       - save_cache:
+           key: v1-{{ .Branch }}-{{ epoch }}
+           paths:
+             - /caches/pipeline.tar
+       - run:
+           name: Run tests
+           command: |
+             docker run pipeline bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest'
+       - store_test_results:
+             path: ~/test_reports_pipeline
 workflows:
    version: 2
-   build-n-deploy:
+   build_and_test:
      jobs:
-       - build:
+       - buildweb:
+           filters:
+             tags:
+               only: /.*/
+       - test-pipeline:
            filters:
              tags:
                only: /.*/
        - deploy-dev:
            requires:
-             - build
+             - buildweb
            filters:
              branches:
                only: master
        - deploy-beta:
            requires:
-             - build
+             - buildweb
            filters:
              tags:
                only: /v[0-9]+(\.[0-9]+)*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,156 +1,53 @@
 version: 2
 jobs:
-   buildweb:
-     docker:
-       - image: circleci/node:6.13
-       - image: circleci/postgres:9.6.2
-         environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: storage.pg
-     steps:
-       - checkout
-       - run:
-           name: Setup npm
-           working_directory: ~/project/website
-           command: npm install
-       - run:
-           name: run linter
-           working_directory: ~/project/website
-           command: |
-             mkdir ~/test_reports
-             npm run lint -- -f junit -o ~/test_reports/lint-results.xml
-       - run:
-           name: run JavaScript tests
-           working_directory: ~/project/website
-           command: npm run test -- -R xunit --reporter-options output=~/test_reports/test-results.xml
-       - run:
-           name: Set up and run website backend tests
-           command: |
-             sudo apt-get install python-pip python-dev
-             sudo pip install virtualenv
-             mkdir ~/project/website_virtualenv
-             virtualenv ~/project/website_virtualenv
-             source ~/project/website_virtualenv/bin/activate
-             pip install -r ~/project/website/requirements.txt
-             pip install -r ~/project/website/test-requirements.txt
-             cd ~/project/website/django && python manage.py migrate
-             python manage.py test
-       - store_test_results:
-           path: ~/test_reports
-   deploy-dev:
-     docker:
-       - image: circleci/node:6.13
-     steps:
-       - checkout
-       - run:
-           name: Setup npm
-           working_directory: ~/project/website
-           command: npm install
-       - run:
-           name: Set up environment for deployment
-           command: |
-             sudo apt-get install rsync
-             [[ ! -d ~/.ssh ]] && mkdir ~/.ssh
-             cat >> ~/.ssh/config << EOF
-                 VerifyHostKeyDNS yes
-                 StrictHostKeyChecking no
-             EOF
-       - run:
-           name: deploying to dev machine
-           command: ~/project/deployment/deploy-dev
-   deploy-beta:
-     docker:
-       - image: circleci/node:6.13
-     steps:
-       - checkout
-       - run:
-           name: Setup npm
-           working_directory: ~/project/website
-           command: npm install
-       - run:
-           name: Set up environment for deployment
-           command: |
-             sudo apt-get install rsync
-             [[ ! -d ~/.ssh ]] && mkdir ~/.ssh
-             cat >> ~/.ssh/config << EOF
-                 VerifyHostKeyDNS yes
-                 StrictHostKeyChecking no
-             EOF
-       - run:
-           name: deploying to beta machine
-           command: HOST=brcaexchange.org ~/project/deployment/deploy-dev
-   test-pipeline:
-     working_directory: /pipeline
-     docker:
-       - image: docker:17.05.0-ce-git
-       # heavily inspired from https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
-     steps:
-       - checkout
-       - setup_remote_docker
-       - run:
-           name: Install dependencies
-           command: |
-             apk add --no-cache \
-               py-pip=9.0.0-r1
-             pip install \
-              docker-compose==1.12.0
-       - restore_cache:
-           keys:
-             - v1-{{ .Branch }}
-           paths:
-             - /caches/pipeline.tar
-       - run:
-           name: Load Docker image layer cache
-           command: |
-             set +o pipefail
-             docker load -i /caches/pipeline.tar | true
-       - run:
-           name: Build application Docker image
-           working_directory: /pipeline/pipeline/docker
-           command: |
-             pwd
-             echo $(pwd)
-             cp ../requirements.txt requirements_docker.txt
-             cp ../../test-requirements.txt test-requirements_docker.txt
-             docker build --cache-from=pipeline -t pipeline .
-       - run:
-           name: Save Docker image layer cache
-           command: |
-             mkdir -p /caches
-             docker save -o /caches/pipeline.tar pipeline
-       - save_cache:
-           key: v1-{{ .Branch }}-{{ epoch }}
-           paths:
-             - /caches/pipeline.tar
-       - run:
-           name: Run tests
-           command: |
-             docker run pipeline bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest'
-       - store_test_results:
-             path: ~/test_reports_pipeline
+   build:
+    working_directory: /splicing-pipeline
+    docker:
+      - image: docker:17.05.0-ce-git
+    # heavily inspired from https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
+    steps:
+      - checkout
+      - setup_remote_docker
+      - run:
+          name: Install dependencies
+          command: |
+            apk add --no-cache \
+              py-pip=9.0.0-r1 make
+      - restore_cache:
+          keys:
+            - v1-{{ .Branch }}
+          paths:
+            - /caches/splicing-pipeline.tar
+      - run:
+          name: Load Docker image layer cache
+          command: |
+            set +o pipefail
+            docker load -i /caches/splicing-pipeline.tar | true
+      - run:
+          name: Build application Docker image
+          working_directory: /splicing-pipeline/pipeline/splicing
+          command: |
+            docker build --cache-from=splicing-pipeline -t splicing-pipeline .
+      - run:
+          name: Save Docker image layer cache
+          command: |
+            mkdir -p /caches
+            docker save -o /caches/splicing-pipeline.tar splicing-pipeline
+      - save_cache:
+          key: v1-{{ .Branch }}-{{ epoch }}
+          paths:
+            - /caches/splicing-pipeline.tar
+      - run:
+          name: Run tests
+          working_directory: /splicing-pipeline/pipeline/splicing
+          command: |
+            make references -e IMAGE_NAME=splicing-pipeline -e REFERENCES=/splicing-pipeline/references
+            make short -e IMAGE_NAME=splicing-pipeline -e REFERENCES=/splicing-pipeline/references
 workflows:
    version: 2
-   build_and_test:
+   build-n-deploy:
      jobs:
-       - buildweb:
+       - build:
            filters:
              tags:
                only: /.*/
-       - test-pipeline:
-           filters:
-             tags:
-               only: /.*/
-       - deploy-dev:
-           requires:
-             - buildweb
-           filters:
-             branches:
-               only: master
-       - deploy-beta:
-           requires:
-             - buildweb
-           filters:
-             tags:
-               only: /v[0-9]+(\.[0-9]+)*/
-             branches:
-               ignore: /.*/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ jobs:
        - run:
            name: Run tests
            command: |
-             docker run pipeline bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest'
+             docker run pipeline bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest --ignore=splicing/ --junitxml=~/test_reports/pytest-results.xml'
        - store_test_results:
              path: ~/test_reports_pipeline
    test-splicing-pipeline:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,52 +1,202 @@
 version: 2
 jobs:
-   build:
-    working_directory: /splicing-pipeline
-    docker:
-      - image: docker:17.05.0-ce-git
+   buildweb:
+     docker:
+       - image: circleci/node:6.13
+       - image: circleci/postgres:9.6.2
+         environment:
+          POSTGRES_USER: postgres
+          POSTGRES_DB: storage.pg
+     steps:
+       - checkout
+       - run:
+           name: Setup npm
+           working_directory: ~/project/website
+           command: npm install
+       - run:
+           name: run linter
+           working_directory: ~/project/website
+           command: |
+             mkdir ~/test_reports
+             npm run lint -- -f junit -o ~/test_reports/lint-results.xml
+       - run:
+           name: run JavaScript tests
+           working_directory: ~/project/website
+           command: npm run test -- -R xunit --reporter-options output=~/test_reports/test-results.xml
+       - run:
+           name: Set up and run website backend tests
+           command: |
+             sudo apt-get install python-pip python-dev
+             sudo pip install virtualenv
+             mkdir ~/project/website_virtualenv
+             virtualenv ~/project/website_virtualenv
+             source ~/project/website_virtualenv/bin/activate
+             pip install -r ~/project/website/requirements.txt
+             pip install -r ~/project/website/test-requirements.txt
+             cd ~/project/website/django && python manage.py migrate
+             python manage.py test
+       - store_test_results:
+           path: ~/test_reports
+   deploy-dev:
+     docker:
+       - image: circleci/node:6.13
+     steps:
+       - checkout
+       - run:
+           name: Setup npm
+           working_directory: ~/project/website
+           command: npm install
+       - run:
+           name: Set up environment for deployment
+           command: |
+             sudo apt-get install rsync
+             [[ ! -d ~/.ssh ]] && mkdir ~/.ssh
+             cat >> ~/.ssh/config << EOF
+                 VerifyHostKeyDNS yes
+                 StrictHostKeyChecking no
+             EOF
+       - run:
+           name: deploying to dev machine
+           command: ~/project/deployment/deploy-dev
+   deploy-beta:
+     docker:
+       - image: circleci/node:6.13
+     steps:
+       - checkout
+       - run:
+           name: Setup npm
+           working_directory: ~/project/website
+           command: npm install
+       - run:
+           name: Set up environment for deployment
+           command: |
+             sudo apt-get install rsync
+             [[ ! -d ~/.ssh ]] && mkdir ~/.ssh
+             cat >> ~/.ssh/config << EOF
+                 VerifyHostKeyDNS yes
+                 StrictHostKeyChecking no
+             EOF
+       - run:
+           name: deploying to beta machine
+           command: HOST=brcaexchange.org ~/project/deployment/deploy-dev
+   test-pipeline:
+     working_directory: /pipeline
+     docker:
+       - image: docker:17.05.0-ce-git
+       # heavily inspired from https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
+     steps:
+       - checkout
+       - setup_remote_docker
+       - run:
+           name: Install dependencies
+           command: |
+             apk add --no-cache \
+               py-pip=9.0.0-r1
+             pip install \
+              docker-compose==1.12.0
+       - restore_cache:
+           keys:
+             - v1-{{ .Branch }}
+           paths:
+             - /caches/pipeline.tar
+       - run:
+           name: Load Docker image layer cache
+           command: |
+             set +o pipefail
+             docker load -i /caches/pipeline.tar | true
+       - run:
+           name: Build application Docker image
+           working_directory: /pipeline/pipeline/docker
+           command: |
+             pwd
+             echo $(pwd)
+             cp ../requirements.txt requirements_docker.txt
+             cp ../../test-requirements.txt test-requirements_docker.txt
+             docker build --cache-from=pipeline -t pipeline .
+       - run:
+           name: Save Docker image layer cache
+           command: |
+             mkdir -p /caches
+             docker save -o /caches/pipeline.tar pipeline
+       - save_cache:
+           key: v1-{{ .Branch }}-{{ epoch }}
+           paths:
+             - /caches/pipeline.tar
+       - run:
+           name: Run tests
+           command: |
+             docker run pipeline bash -c 'cd /opt/brca-exchange/pipeline/data && bash getdata && cd /opt/brca-exchange/pipeline && pytest'
+       - store_test_results:
+             path: ~/test_reports_pipeline
+   test-splicing-pipeline:
+     working_directory: /splicing-pipeline
+     docker:
+       - image: docker:17.05.0-ce-git
     # heavily inspired from https://circleci.com/blog/how-to-build-a-docker-image-on-circleci-2-0/
-    steps:
-      - checkout
-      - setup_remote_docker
-      - run:
-          name: Install dependencies
-          command: |
-            apk add --no-cache \
-              py-pip=9.0.0-r1 make
-      - restore_cache:
-          keys:
-            - v1-{{ .Branch }}
-          paths:
-            - /caches/splicing-pipeline.tar
-      - run:
-          name: Load Docker image layer cache
-          command: |
-            set +o pipefail
-            docker load -i /caches/splicing-pipeline.tar | true
-      - run:
-          name: Build application Docker image
-          working_directory: /splicing-pipeline/pipeline/splicing
-          command: |
-            docker build --cache-from=splicing-pipeline -t splicing-pipeline .
-      - run:
-          name: Save Docker image layer cache
-          command: |
-            mkdir -p /caches
-            docker save -o /caches/splicing-pipeline.tar splicing-pipeline
-      - save_cache:
-          key: v1-{{ .Branch }}-{{ epoch }}
-          paths:
-            - /caches/splicing-pipeline.tar
-      - run:
-          name: Run tests
-          working_directory: /splicing-pipeline/pipeline/splicing
-          command: |
-            make unit_tests_docker -e IMAGE_NAME=splicing-pipeline
+     steps:
+       - checkout
+       - setup_remote_docker
+       - run:
+           name: Install dependencies
+           command: |
+             apk add --no-cache \
+               py-pip=9.0.0-r1 make
+       - restore_cache:
+           keys:
+             - v1-{{ .Branch }}
+           paths:
+             - /caches/splicing-pipeline.tar
+       - run:
+           name: Load Docker image layer cache
+           command: |
+             set +o pipefail
+             docker load -i /caches/splicing-pipeline.tar | true
+       - run:
+           name: Build application Docker image
+           working_directory: /splicing-pipeline/pipeline/splicing
+           command: |
+             docker build --cache-from=splicing-pipeline -t splicing-pipeline .
+       - run:
+           name: Save Docker image layer cache
+           command: |
+             mkdir -p /caches
+             docker save -o /caches/splicing-pipeline.tar splicing-pipeline
+       - save_cache:
+           key: v1-{{ .Branch }}-{{ epoch }}
+           paths:
+             - /caches/splicing-pipeline.tar
+       - run:
+           name: Run tests
+           working_directory: /splicing-pipeline/pipeline/splicing
+           command: |
+             make unit_tests_docker -e IMAGE_NAME=splicing-pipeline
 workflows:
    version: 2
    build-n-deploy:
      jobs:
-       - build:
+       - buildweb:
            filters:
              tags:
                only: /.*/
+       - test-pipeline:
+           filters:
+             tags:
+               only: /.*/
+       - test-splicing-pipeline:
+          filters:
+             tags:
+               only: /.*/
+       - deploy-dev:
+           requires:
+             - buildweb
+           filters:
+             branches:
+               only: master
+       - deploy-beta:
+           requires:
+             - buildweb
+           filters:
+             tags:
+               only: /v[0-9]+(\.[0-9]+)*/
+             branches:
+               ignore: /.*/

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -102,8 +102,10 @@ You may log in to circle-ci with your github credentials.
 Version 2.0 of CCI can easily be run locally as well using
 
 ```
-circleci build
+circleci build --job [job-name]
 ```
+
+where `job-name` for example is `buildweb`, `test-pipeline` or `test-splicing-pipeline` (see also `brca-exchange/.circleci/config.yml`)
 
 See the [local client documentation](https://circleci.com/docs/2.0/local-cli/) for more details, also regarding installation.
 

--- a/pipeline/docker/Dockerfile
+++ b/pipeline/docker/Dockerfile
@@ -1,7 +1,9 @@
 FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y \
+    curl \
     git \
+    libmysqlclient-dev \
     liblzo2-dev \
     pkg-config \
     python-pip \
@@ -14,11 +16,13 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /opt
 
 COPY requirements_docker.txt .
+COPY test-requirements_docker.txt .
 
 # install numpy first to avoid issues with bio python and bx-python (see also https://github.com/LUMC/vep2lovd/issues/1)
 RUN pip install $(grep numpy requirements_docker.txt)
 
-RUN pip install -r requirements_docker.txt
+RUN pip install -r requirements_docker.txt -r test-requirements_docker.txt
+
 
 # install vcf tools
 RUN wget https://github.com/vcftools/vcftools/releases/download/v0.1.15/vcftools-0.1.15.tar.gz

--- a/pipeline/splicing/Makefile
+++ b/pipeline/splicing/Makefile
@@ -26,6 +26,13 @@ test:
 	# Run a short test from within the docker container
 	python calcVarPriors.py test short
 
+unit_tests_docker:
+	docker run --rm -it \
+		--user=`id -u`:`id -g` \
+    --entrypoint pytest \
+		$(IMAGE_NAME)
+
+
 references:
 	# Download and install references
 	mkdir -p $(REFERENCES)

--- a/pipeline/splicing/Makefile
+++ b/pipeline/splicing/Makefile
@@ -1,11 +1,12 @@
 # Host path where references should be stored - symlink tolerant
 REFERENCES = $(shell readlink -f ~/references/splicing)
+IMAGE_NAME = $(USER)-splicing-pipeline
 
 default: build references short
 
 build:
 	# Build and tag the image prefixed by user to avoid conflicts on shared machines
-	docker build -t $(USER)-splicing-pipeline .
+	docker build -t $(IMAGE_NAME) .
 
 push:
 	# Tag and push our current docker build to dockerhub
@@ -19,7 +20,7 @@ debug:
 		--user=`id -u`:`id -g` \
 		-v `readlink -f $(REFERENCES)`:/references \
 		-v `pwd`:/app \
-		$(USER)-splicing-pipeline
+	  $(IMAGE_NAME)
 
 test:
 	# Run a short test from within the docker container
@@ -31,14 +32,14 @@ references:
 	docker run --rm -it \
 		--user=`id -u`:`id -g` \
 		-v `readlink -f $(REFERENCES)`:/references \
-		$(USER)-splicing-pipeline references
+		$(IMAGE_NAME) references
 
 short:
 	# Run a short test using the docker container
 	docker run --rm -it \
 		--user=`id -u`:`id -g` \
 		-v `readlink -f $(REFERENCES)`:/references:ro \
-		$(USER)-splicing-pipeline test short
+		$(IMAGE_NAME) test short
 
 long:
 	# Run a long test using the docker container with 22 cores


### PR DESCRIPTION
* running splicing (unit) tests in the appropriate docker container on circleci
* also moving main pipeline unit testing in its own docker container

In a subsequent iteration, also the tests requiring reference data could be run on circleci leveraging the caching mechanism. I could however not get it to work yet.